### PR TITLE
Add support for custom file associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ Multiple languages supported.
 
 <hr/>
 
+### Custom File Associations for dotenv Files
+
+To define custom file associations for `dotenv` files in `settings.json`, use the `dotenv.files.associations` setting. This allows you to associate custom file patterns with the `dotenv` language, enabling syntax highlighting, auto-cloaking, auto-completion, and in-code secret peeking for those files.
+
+For example, to associate all files in a `.env.d` directory as `dotenv` files, add the following to your `settings.json`:
+
+```json
+{
+  "dotenv.files.associations": {
+    "**/.env.d/*": "dotenv"
+  }
+}
+```
+
+This feature enhances flexibility in managing environment variables across different projects and setups.
+
+<hr/>
+
 ### dotenv-vault (included but optional)
 
 Manage your secrets using <strong>dotenv-vault</strong>'s all-in-one toolkit. Say goodbye to scattered secrets across multiple platforms and tools.

--- a/lib/fileAssociations.js
+++ b/lib/fileAssociations.js
@@ -1,9 +1,20 @@
-const settings = require('./settings')
+const vscode = require('vscode');
+const settings = require('./settings');
 
 const run = function () {
-  settings.populateFileAssociations()
+  // Retrieve custom file associations from settings.json
+  const customAssociations = vscode.workspace.getConfiguration().get('dotenv.files.associations');
 
-  return true
+  // Populate default file associations
+  settings.populateFileAssociations();
+
+  // Merge custom file associations with default ones
+  const fileAssociations = vscode.workspace.getConfiguration('files');
+  for (const [pattern, language] of Object.entries(customAssociations)) {
+    fileAssociations.update('associations', { ...fileAssociations.get('associations'), [pattern]: language }, vscode.ConfigurationTarget.Global);
+  }
+
+  return true;
 }
 
-module.exports.run = run
+module.exports.run = run;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "*",
+    "onLanguage:dotenv"
   ],
   "main": "./extension.js",
   "contributes": {
@@ -60,6 +61,12 @@
           "type": "string",
           "default": "█",
           "description": "Change the icon of the cloak for your .env files"
+        },
+        "dotenv.files.associations": {
+          "scope": "resource",
+          "type": "object",
+          "default": {},
+          "description": "Custom file associations for dotenv files"
         }
       }
     },


### PR DESCRIPTION
Related to #103

Introduces custom file associations for `dotenv` files through `settings.json`, enhancing flexibility and user configuration options.

- **Package.json Updates:**
  - Adds a new configuration setting `dotenv.files.associations` to allow users to define custom file associations for `dotenv` files.
  - Updates `activationEvents` to include `onLanguage:dotenv`, ensuring the extension activates for custom file associations.

- **Code Logic Enhancement:**
  - Modifies `lib/fileAssociations.js` to read custom file associations from `settings.json` and merges them with default associations. This allows for dynamic association of files with the `dotenv` language based on user preferences.

- **Documentation:**
  - Updates `README.md` to include instructions on how to define custom file associations for `dotenv` files in `settings.json`, providing clear guidance for users to leverage this new feature.


---

I needed this feature for allowing files like `.dev.vars` to be cloaked during stream. Used copilot workspace to make a PR

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dotenv-org/dotenv-vscode/issues/103?shareId=7c05be5a-f113-4f7b-ad08-7c81b6e13fd7).