### PR TITLE
fix: TypeError: Cannot read properties of undefined (reading 'uri')

### DIFF
--- a/lib/autocloaking.js
+++ b/lib/autocloaking.js
@@ -27,7 +27,7 @@ function decorateMasking (context) {
   vscode.workspace.onDidOpenTextDocument(function (event) {
     const openEditor = vscode.window.visibleTextEditors.filter(function (editor) {
       try {
-        return editor.document.uri === event.document.uri
+        return editor.document.uri === event.uri
       } catch (e) {
         console.log(e)
         return false


### PR DESCRIPTION
I found that the dotenv-vscode extention clutters the vscode logs (`Developer: Toggle Developer Tools`) with the following exception:

```
[Extension Host] onDidOpenTextDocument
console.ts:137 [Extension Host] TypeError: Cannot read properties of undefined (reading 'uri')
	at /Users/ilya/.vscode/extensions/dotenv.dotenv-vscode-0.28.1/lib/autocloaking.js:30:55
	at Array.filter (<anonymous>)
	at /Users/ilya/.vscode/extensions/dotenv.dotenv-vscode-0.28.1/lib/autocloaking.js:28:57
	at od.value (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:199:101661)
	at $.C (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2373)
	at $.D (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2443)
	at $.fire (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2660)
	at od.value (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:140:106179)
	at $.C (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2373)
	at $.fire (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2591)
	at Fy.acceptDocumentsAndEditorsDelta (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:120:11840)
	at Fy.$acceptDocumentsAndEditorsDelta (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:120:10425)
	at j4.S (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:120180)
	at j4.Q (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:119960)
	at j4.M (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:119049)
	at j4.L (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:118154)
	at od.value (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:116951)
	at $.C (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2373)
	at $.fire (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2591)
	at vo.fire (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:9458)
	at od.value (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:391:8617)
	at $.C (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2373)
	at $.fire (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:27:2591)
	at vo.fire (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:29:9458)
	at MessagePortMain.<anonymous> (file:///Users/ilya/opt/opt/vscode-apple-silicon_1.102.1.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:391:6909)
	at MessagePortMain.emit (node:events:518:28)
	at MessagePortMain._internalPort.emit (node:electron/js2c/utility_init:2:2949)
```

From the https://code.visualstudio.com/api/references/vscode-api, it is clear that event is document so, this is the simple fix.